### PR TITLE
Fix multi.dot Graphviz regression test

### DIFF
--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -194,11 +194,11 @@ class TestGraphAPI(unittest.TestCase):
 
     def _render_with_pydot(self, filename, encoding):
         c = pydot.graph_from_dot_file(filename, encoding=encoding)
-        sha = ''
+        jpe_data = bytearray()
         for g in c:
-            jpe_data = g.create(prog=TEST_PROGRAM, format='jpe', encoding=encoding)
-            sha += sha256(jpe_data).hexdigest()
-        return sha
+            jpe_data.extend(g.create(prog=TEST_PROGRAM, format='jpe',
+                                     encoding=encoding))
+        return sha256(jpe_data).hexdigest()
 
     def test_my_regression_tests(self):
         path = os.path.join(test_dir, TESTS_DIR_1)


### PR DESCRIPTION
Commit d6602ad of 2018-12-01 fixed the regression test broken by commit
2d55978 of 2016-07-01. This revealed that `test/graphs/multi.dot` was
failing.

`multi.dot` was introduced in commit 2b3f088 of 2010-11-07 together
with many of the other tests still here today. It has not been touched
since. It is a DOT-file containing two digraphs. The regression test
compares the JPEG images rendered from the DOT-file by pydot with those
rendered by Graphviz's dot directly.

Commit 66734d2 of 2016-07-01 is the actual cause of the failure. It
changed one of the render methods of the regression test,
`_render_with_pydot`, from calculating a single hash for all the JPEG
images to calculating separate hashes for each JPEG image and then
concatenating those hashes in one long string. The other render method,
`_render_with_graphviz`, still calculates a single hash over all data.
For DOT-files that generate only one image the end result is the same,
but because `multi.dot` has two graphs, it produces two images and this
leads to comparing a string of two hashes with one single hash.

I do not think the change in generating the hash was intentional, for
the following reasons:
- Commit 66734d2 states that its purpose was to adapt the test to an
  API change in pydot. It does not mention a deliberate choice to
  change the testing method.
- There was no effort to change `_render_with_graphviz` to also produce
  multiple hashes.
- Except for easier debugging in case of a failing test with multiple
  images (AFAICT, only `multi.dot`), I do not see much added benefit in
  checking a concatenation of the hashes of all images vs. checking one
  hash of all images together: In both cases the test will fail if one
  or more images is rendered differently.
- Given that there were many commits authored that same hour, including
  commit 2d55978 which broke the regression tests, I suspect the author
  did not run the tests for each individual commit, but only at the end
  of that batch, and was therefore also not alerted of this change by
  the test suite.

Assuming that the change was not intended, this commit will now revert
`_render_with_pydot` to the old behavior of calculating a single hash
from all JPEG image data.

Tested with Debian 9.9, Graphviz 2.38.0-17, Python 2.7.13-2 and 3.5.3-1.

Fixes https://github.com/pydot/pydot/issues/204.