### PR TITLE
Add our DOT string when reporting Graphviz errors

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -1932,13 +1932,16 @@ class Dot(Graph):
         if process.returncode != 0:
             message = (
                 '"{prog}" with args {arguments} returned code: {code}\n\n'
-                'stdout, stderr:\n {out}\n{err}\n'
+                'stdout from "{prog}":\n{out}\n\n'
+                'stderr from "{prog}":\n{err}\n\n'
+                'DOT string sent to "{prog}":\n{dotstring}\n\n'
             ).format(
                 prog=prog,
                 arguments=arguments,
                 code=process.returncode,
                 out=stdout_data,
                 err=stderr_data,
+                dotstring=self.to_string(),
             )
             print(message)
 


### PR DESCRIPTION
When pydot calls Graphviz and Graphviz returns a non-zero exit code
(indicating an error), pydot currently reports the Graphviz stdout and
stderr output and raises an exception.

This commit adds to that error report the 'raw' DOT string generated by
pydot, as it was also sent to Graphviz as input.

Also, this commit separates the Graphviz stdout and stderr output more
clearly.

These changes should help in troubleshooting Graphviz errors.

For some examples where this would have helped see:
https://github.com/pydot/pydot/issues/203
("Problem with graph.write.png...AssertionError: 1")

Tested with Python 2.7 and 3.7. All tests pass (when run together with
the test suite fix proposed in PR 211).