### PR TITLE
Fix and improve printing of pyparsing errors

### DIFF
--- a/dot_parser.py
+++ b/dot_parser.py
@@ -548,8 +548,13 @@ def parse_dot_data(s):
         tokens = graphparser.parseString(s)
         return list(tokens)
     except ParseException as err:
-        print(
-            err.line +
-            " "*(err.column-1) + "^" +
-            err)
+        if PY3 and (hasattr(ParseException, 'explain') and
+                    callable(getattr(ParseException, 'explain'))):
+            print(ParseException.explain(err))
+        else:
+            print(
+                err.line + "\n" +
+                " "*(err.column-1) + "^\n" +
+                str(err)
+                )
         return None


### PR DESCRIPTION
When parsing DOT strings or files, pydot's parser calls the third-party
library pyparsing. If pyparsing meets a problem, it raises a
`ParseException`, which pydot's parser then reports.

This commit makes some improvements to that reporting:

- Use `str(err)` instead of just `err` to prevent errors such as:
  Python 2.7:

      TypeError: cannot concatenate 'str' and 'ParseException' objects

  Python 3.7:

      TypeError: can only concatenate str (not "ParseException") to str

  This closes https://github.com/pydot/pydot/issues/176 ("Error in
  error handling hides the real error message"), reported by Shish.
- Add newlines where necessary.
- When running under Python 3, use the `ParseException.explain()`
  method if it is available. This method was introduced in pyparsing
  2.3.1 of January 2019 [1] [2]. It returns the same information that
  we otherwise manually string together (line, column arrow and error
  message), and adds to that a list of the pyparsing expressions that
  caused the exception to be raised.

I verified the new behavior by manually testing under the four
combinations of Python 2.7.16/3.7.3 and pyparsing 2.3.0/2.4.2.

Unit tests all pass (same four combinations, when run together with the
test suite fix proposed in PR 211).

[1]: https://github.com/pyparsing/pyparsing/blob/pyparsing_2.4.2/CHANGES#L396
[2]: https://github.com/pyparsing/pyparsing/blob/pyparsing_2.4.2/pyparsing.py#L378